### PR TITLE
Add GitHub Actions workflow for Discord notifications

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - name: Send notification to Discord
         run: |
-          curl -H "Content-Type: application/json" ^
-          -d "{\"content\": \" GitHub event: ${{ github.event_name }} by ${{ github.actor }}\"}" ^
-          ${{ secrets.DISCORD_WEBHOOK_URL }}
+          curl -H "Content-Type: application/json" \
+          -d "{\"content\": \"GitHub event: ${{ github.event_name }} by ${{ github.actor }}\"}" \
+          "${{ secrets.DISCORD_WEBHOOK_URL }}"


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that sends GitHub activity updates
(pushes, pull requests, and issues) to a Discord channel using a webhook.

## Motivation
Keeping contributors informed of repository activity directly in Discord
helps improve collaboration and reduces the need to constantly check GitHub.

## What’s Included
- GitHub Actions workflow for Discord notifications
- Supports push, pull request, and issue events
- Uses Discord webhooks with JSON payloads

## Related Issue
Closes #5 — GitHub to Discord Notification System (MS1: Discord Integration)
