### PR TITLE
fix: making YOLO weights actually work and improve setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,8 +167,6 @@ Desktop.ini
 *~
 
 # Project-specific ignores
-*.md
-*.rst
 *.log
 *.logs
 logs/
@@ -205,3 +203,8 @@ ui-debug.log
 RUXAILAB/node_modules/
 RUXAILAB/dist/
 RUXAILAB/.firebase/
+
+# Model weights
+weights/**/*.pt
+weights/**/*.pth
+weights/**/*.bin

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ This will start:
 - Firebase emulators on http://127.0.0.1:4000
 - API docs at http://localhost:8000/docs
 
+### Prerequisites: Download Model Weights
+
+This project uses **Microsoft OmniParser** for UI element detection, which requires downloading a custom YOLO model (~40MB).
+
+**Download the model:**
+
+```bash
+# Create weights directory
+mkdir -p weights/icon_detect
+
+# Download using wget
+wget https://huggingface.co/microsoft/OmniParser/resolve/main/icon_detect/model.pt \
+  -O weights/icon_detect/model.pt
+
 ### Manual Setup
 
 1. **Start AI Heuristic Service**

--- a/README.md
+++ b/README.md
@@ -68,15 +68,26 @@ This system combines Microsoft's OmniParser for UI element detection with LLM-ba
 
 This project uses **Microsoft OmniParser** for UI element detection, which requires downloading a custom YOLO model (~40MB).
 
+
 **Download the model:**
 
 ```bash
 # Create weights directory
 mkdir -p weights/icon_detect
+```
 
-# Download using wget
+You can use either `wget` or `curl` to download the model:
+
+**Using wget:**
+```bash
 wget https://huggingface.co/microsoft/OmniParser/resolve/main/icon_detect/model.pt \
   -O weights/icon_detect/model.pt
+```
+
+**Or using curl:**
+```bash
+curl -L https://huggingface.co/microsoft/OmniParser/resolve/main/icon_detect/model.pt \
+  -o weights/icon_detect/model.pt
 ```
 
 ### Using the Development Script

--- a/README.md
+++ b/README.md
@@ -64,19 +64,6 @@ This system combines Microsoft's OmniParser for UI element detection with LLM-ba
 
 ## Quick Start
 
-### Using the Development Script
-
-```bash
-chmod +x start-dev.sh
-./start-dev.sh
-```
-
-This will start:
-- RUXAILAB Vue.js app on http://localhost:8081
-- AI Heuristic API on http://localhost:8000
-- Firebase emulators on http://127.0.0.1:4000
-- API docs at http://localhost:8000/docs
-
 ### Prerequisites: Download Model Weights
 
 This project uses **Microsoft OmniParser** for UI element detection, which requires downloading a custom YOLO model (~40MB).
@@ -90,6 +77,20 @@ mkdir -p weights/icon_detect
 # Download using wget
 wget https://huggingface.co/microsoft/OmniParser/resolve/main/icon_detect/model.pt \
   -O weights/icon_detect/model.pt
+```
+
+### Using the Development Script
+
+```bash
+chmod +x start-dev.sh
+./start-dev.sh
+```
+
+This will start:
+- RUXAILAB Vue.js app on http://localhost:8081
+- AI Heuristic API on http://localhost:8000
+- Firebase emulators on http://127.0.0.1:4000
+- API docs at http://localhost:8000/docs
 
 ### Manual Setup
 

--- a/app/services/omniparser_client.py
+++ b/app/services/omniparser_client.py
@@ -208,7 +208,7 @@ class OmniParserClient:
     async def initialize(self):
         self.logger.info("Initializing OmniParser client...")
         # Loading YOLO 
-        self.yolo_model = YOLO("weights/icon_detect/best.pt")
+        self.yolo_model = YOLO("weights/icon_detect/model.pt")
         
         # Loading Florence-2 
         self.caption_model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
## 🐛 Problem

Contributors encounter `FileNotFoundError` when starting the server. 

### Impact: Critical 
Server startup blocked for new contributors, preventing run the app 
> Sub-issue of MVP demo working on.

---

## 🔍 Root Cause

1. Code expects `best.pt`, but Microsoft OmniParser releases as `model.pt`
2. No setup documentation for downloading model weights
3. Missing `.gitignore` patterns risk committing 40MB+ files
4. `.gitignore` had `*.md` and `*.rst` blocking docs

---

## ✅ Solution

**Code:** Updated to use `model.pt` (matches OmniParser naming)

**Repository Safety:** Added `.gitignore` patterns:
```gitignore
weights/**/*.pt
weights/**/*.pth
weights/**/*.bin
```
