### PR TITLE
fix: deduplicate OmniParser init and reuse HeuristicEngine as singleton

### DIFF
--- a/app/api/routes/evaluation.py
+++ b/app/api/routes/evaluation.py
@@ -57,9 +57,8 @@ async def evaluate_heuristics(
         
         detection_result = await detection_client.detect_elements(contents)
 
-        # Initialize evaluation engine and evaluate
-        evaluation_engine = HeuristicEvaluationEngine()
-        await evaluation_engine.initialize()
+        # Use singleton evaluation engine from app.state (avoids re-initializing on every request)
+        evaluation_engine = request.app.state.heuristic_engine
 
         evaluation_result = await evaluation_engine.evaluate_interface(detection_result)
 

--- a/main.py
+++ b/main.py
@@ -32,23 +32,20 @@ app.include_router(evaluation.router, prefix="/api/v1/evaluation", tags=["evalua
 
 @app.on_event("startup")
 async def startup_event():
-    # Initialize OmniParser Client (Singleton)
-    app.state.omniparser_client = OmniParserClient()
-    await app.state.omniparser_client.initialize()
-    
     setup_logging()
     logger = logging.getLogger(__name__)
     logger.info("AI Heuristic Evaluation API starting up...")
 
-    # Initialize singleton OmniParser client to avoid re-initializing model on every request
+    # Initialize singleton OmniParser client (avoids re-initializing model on every request)
     app.state.omniparser_client = OmniParserClient()
     await app.state.omniparser_client.initialize()
     logger.info("OmniParser client initialized (singleton)")
 
-    heuristic_engine = HeuristicEvaluationEngine()
-    await heuristic_engine.initialize()
-
-    logger.info("Heuristic evaluation engine initialized")
+    # Initialize singleton Heuristic Evaluation Engine on app.state
+    # so route handlers can reuse it instead of re-creating per request
+    app.state.heuristic_engine = HeuristicEvaluationEngine()
+    await app.state.heuristic_engine.initialize()
+    logger.info("Heuristic evaluation engine initialized (singleton)")
 
 @app.on_event("shutdown")
 async def shutdown_event():


### PR DESCRIPTION
<html><head></head><body><h1>fix: remove duplicate OmniParser initialization and store HeuristicEvaluationEngine as singleton</h1>
<h2>Problem</h2>
<p>Two issues in the current startup and request handling:</p>
<ol>
<li>
<p><strong>Duplicate OmniParser initialization in <code>main.py</code></strong> — <code>OmniParserClient()</code> is created and initialized twice during startup (lines 36–37 and lines 44–45), meaning the model is loaded into memory twice unnecessarily.</p>
</li>
<li>
<p><strong>HeuristicEvaluationEngine re-created on every request</strong> — In <code>evaluation.py</code>, the <code>/evaluate</code> endpoint creates a new <code>HeuristicEvaluationEngine()</code> and calls <code>await evaluation_engine.initialize()</code> on every single request. This re-initializes the OpenAI client and the RAG knowledge base each time, adding unnecessary latency and memory overhead.</p>
</li>
</ol>
<h2>Fix</h2>
<ul>
<li>
<p><strong><code>main.py</code></strong>: Removed the duplicate <code>OmniParserClient</code> initialization. Stored <code>HeuristicEvaluationEngine</code> on <code>app.state.heuristic_engine</code> as a singleton, matching the existing pattern used for <code>app.state.omniparser_client</code>.</p>
</li>
<li>
<p><strong><code>app/api/routes/evaluation.py</code></strong>: Updated the <code>/evaluate</code> endpoint to use <code>request.app.state.heuristic_engine</code> instead of creating a new engine instance per request.</p>
</li>
</ul>
<h2>Files Changed</h2>

File | Change
-- | --
main.py | Removed duplicate OmniParser init; added app.state.heuristic_engine singleton
app/api/routes/evaluation.py | Use singleton engine from app.state instead of re-creating per request


<h2>Testing</h2>
<ul>
<li>Existing integration test (<code>tests/test_integration_real.py</code>) is unaffected — it creates its own engine instance directly.</li>
<li>The <code>/evaluate</code> endpoint behavior is unchanged; only the initialization strategy differs.</li>
</ul></body></html>